### PR TITLE
Change ROOT_FOLDER, allows it to run on my system at least

### DIFF
--- a/.misc/utils.sh
+++ b/.misc/utils.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Save the root directory of this git repository
-ROOT_FOLDER=$(cd `dirname $0` && pwd)/..
+ROOT_FOLDER=$(cd `dirname -- $0` && pwd)/
 
 # Save the user prompt before editing it,
 # taking care that it is only saved once.


### PR DESCRIPTION
Original solution outputs this:

    ola@~/terminal-workshop$ cd `dirname $0` && pwd
    dirname: illegal option -- b
    usage: dirname path
    /Users/ola

With '--' inserted and keeping the trailing dots:

    ola@~/terminal-workshop$ source ./.misc/utils.sh
    ola@~/terminal-workshop$ echo $ROOT_FOLDER
    /Users/ola/terminal-workshop/..

This turns line 15 of the script into:

    /Users/ola/terminal-workshop/../.misc/requirements.txt

Which doesn't exist.

So removing the trailing dots and inserting -- returns this:

    ola@~/terminal-workshop$ source ./.misc/utils.sh
    ola@~/terminal-workshop$ echo $ROOT_FOLDER
    /Users/ola/terminal-workshop/